### PR TITLE
feat!: allow insert / upsert config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,16 @@ meltano add loader target-airtable --from-ref https://raw.githubusercontent.com/
 
 ### Accepted Config Options
 
-| Property | Required | Description |
+|Property | Required |Description |
 |:---|:---|:---|
-| `token` | Yes | Airtable API token |
-| `base_id` | Yes | Airtable base ID |
-| `table_mapping` | Yes | Mapping of stream to Airtable table id |
-| `table_primary_fields` | No | Mapping of stream to array of Airtable fields that should be used as primary key. If not given, `id` must be present in the records |
-| `destructive` | No | If set to `true`, the target will delete all fields that are not present in the stream but are present in Airtable. Default is `false`. |
-| `table_fields_mapping` | No | Mapping of stream to Airtable fields. If not given, all fields will be used. You may use special value `__NULL__` to omit a field completely. |
+|`token` | Yes | The token to authenticate against Airtable API |
+|`base_id` | Yes | Airtable base ID |
+|`streams` | No | Configuration for each of the input streams |
+|`streams.<stream_name>.destructive` | No | If `true`, fields missing in the source stream that exist in the destination will be deleted from Airtable. Default is `false`. |
+|`streams.<stream_name>.table_id` | No | The Airtable table id this stream should be poured into. By default, it is expected that the Airtable table name matches the stream name. |
+|`streams.<stream_name>.upsert` | No | If `true`, data from the stream will be upserted into the Airtable table. Default is `false`. |
+|`streams.<stream_name>.match_fields` | No | If upserting, list the fields that should act as a primary key for the Airtable table. Fields must exist on all records. |
+|`streams.<stream_name>.fields_mapping` | No | A primitive fields mapping to be used with taps that do not support stream maps. Use `field: __NULL__` to exclude and `old_field: new_field` to rename field. |
 
 ## Stream maps
 
@@ -80,11 +82,12 @@ target:
   name: target-airtable
   config:
     ...
-    table_fields_mapping:
+    streams:
       products:
-        full_name: Full Name  # `full_name` will not be present in the Airtable, only `Full Name`
-        i_dont_want_this_field: __NULL__
-        # All fields not present here will be used as is
+        fields_mapping:
+          full_name: Full Name  # `full_name` will not be present in the Airtable, only `Full Name`
+          i_dont_want_this_field: __NULL__
+          # All fields not present here will be used as is
 ...
 ```
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -73,13 +73,7 @@ plugins:
         - name: token
           kind: string
           sensitive: true
-        - name: table_mapping
-          kind: object
-        - name: table_primary_fields
+        - name: streams
           kind: object
         - name: base_id
           kind: string
-        - name: destructive
-          kind: boolean
-        - name: table_fields_mapping
-          kind: object

--- a/target-airtable.yml
+++ b/target-airtable.yml
@@ -19,14 +19,8 @@ settings:
   - name: token
     kind: string
     sensitive: true
-  - name: table_mapping
-    kind: object
-  - name: table_primary_fields
+  - name: streams
     kind: object
   - name: base_id
     kind: string
-  - name: destructive
-    kind: boolean
-  - name: table_fields_mapping
-    kind: object
 variant: tomasvotava

--- a/target_airtable/target.py
+++ b/target_airtable/target.py
@@ -17,36 +17,63 @@ class TargetAirtable(Target):
             "token", th.StringType, description="The token to authenticate against Airtable API", required=True
         ),
         th.Property(
-            "table_mapping",
-            th.ObjectType(additional_properties=th.StringType),
-            description="Mapping of source stream => airtable table id",
-            required=True,
-        ),
-        th.Property(
-            "table_primary_fields",
-            th.ObjectType(additional_properties=th.ArrayType(th.StringType)),
-            description=(
-                "A mapping of source stream => list of record primary fields as visible in Airbyte. "
-                "Defaults to the internal 'id' for each stream."
+            "streams",
+            th.ObjectType(
+                additional_properties=th.ObjectType(
+                    th.Property(
+                        "destructive",
+                        th.BooleanType,
+                        description=(
+                            "If true, fields missing in the source stream that exist "
+                            "in the destination will be deleted from Airtable"
+                        ),
+                        default=False,
+                    ),
+                    th.Property(
+                        "table_id",
+                        th.StringType,
+                        nullable=True,
+                        default=None,
+                        description=(
+                            "The Airtable table id this stream should be poured into. "
+                            "By default it is expected that the Airtable table name matches the stream name."
+                        ),
+                    ),
+                    th.Property(
+                        "upsert",
+                        th.BooleanType,
+                        default=False,
+                        description=(
+                            "If true, data from stream will be upserted into the Airtable table. "
+                            "Upserted stream must either include `id` field or `match_fields` "
+                            "must be set on the stream."
+                        ),
+                    ),
+                    th.Property(
+                        "match_fields",
+                        th.ArrayType(th.StringType),
+                        nullable=True,
+                        default=None,
+                        description=(
+                            "If upserting, list the fields that should act as a primary key for the Airtable table. "
+                            "Fields must exist on all records."
+                        ),
+                    ),
+                    th.Property(
+                        "fields_mapping",
+                        th.ObjectType(additional_properties=th.StringType),
+                        nullable=True,
+                        default=None,
+                        description=(
+                            "A primitive fields mapping to be used with taps that do not support stream maps. "
+                            "Use `field: __NULL__` to exclude and `old_field: new_field` to rename field."
+                        ),
+                    ),
+                ),
             ),
+            description="The configuration for each of the input streams",
+            required=False,
         ),
         th.Property("base_id", th.StringType, description="Airtable base id", required=True),
-        th.Property(
-            "destructive",
-            th.BooleanType,
-            description=(
-                "If true, fields missing in the source existing "
-                "in the destination will be deleted from the destination"
-            ),
-            default=False,
-        ),
-        th.Property(
-            "table_fields_mapping",
-            th.ObjectType(additional_properties=th.ObjectType(additional_properties=th.StringType)),
-            description=(
-                "An optional mapping of stream_name => {field => renamed_field} to allow renaming "
-                "field from streams that do not support stream mapping."
-            ),
-        ),
     ).to_dict()
     default_sink_class = AirtableSink


### PR DESCRIPTION
BREAKING CHANGES
configuration was restructurized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `streams` configuration structure for enhanced management of Airtable loader settings.
	- Added options for `destructive`, `table_id`, `upsert`, `match_fields`, and `fields_mapping` for granular control over data streams.
	- Implemented a new `insert_batch` method for batch record insertion with error handling.

- **Bug Fixes**
	- Improved error handling and logging for stream processing.

- **Documentation**
	- Updated README and configuration files to reflect new settings and provide clearer descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->